### PR TITLE
Actually storing the value pasted into the public key field

### DIFF
--- a/PHPCI/Controller/ProjectController.php
+++ b/PHPCI/Controller/ProjectController.php
@@ -312,7 +312,10 @@ class ProjectController extends PHPCI\Controller
         $form->setMethod('POST');
         $form->setAction(PHPCI_URL.'project/' . $type);
         $form->addField(new Form\Element\Csrf('csrf'));
-        $form->addField(new Form\Element\Hidden('pubkey'));
+
+        $field = new Form\Element\Hidden('pubkey');
+        $field->setId('pubkey-hidden');
+        $form->addField($field);
 
         $options = array(
             'choose' => Lang::get('select_repository_type'),

--- a/PHPCI/Languages/lang.en.php
+++ b/PHPCI/Languages/lang.en.php
@@ -94,9 +94,10 @@ PHPCI',
     'project_details' => 'Project Details',
     'public_key_help' => 'To make it easier to get started, we\'ve generated an SSH key pair for you to use
                             for this project. To use it, just add the following public key to the "deploy keys" section
-                            of your chosen source code hosting platform. Alternatively, if you are using your own ssh 
-                            key pair, paste the private key in the private key box to the left and the public key in 
-                            the box below.',
+                            of your chosen source code hosting platform.
+                            <br><br>
+                            Alternatively, if you are using your own ssh key pair, paste the private key in the private 
+                            key box to the left and the public key in the box below.',
     'select_repository_type' => 'Select repository type...',
     'github' => 'GitHub',
     'bitbucket' => 'Bitbucket',

--- a/PHPCI/Languages/lang.en.php
+++ b/PHPCI/Languages/lang.en.php
@@ -94,7 +94,9 @@ PHPCI',
     'project_details' => 'Project Details',
     'public_key_help' => 'To make it easier to get started, we\'ve generated an SSH key pair for you to use
                             for this project. To use it, just add the following public key to the "deploy keys" section
-                            of your chosen source code hosting platform.',
+                            of your chosen source code hosting platform. Alternatively, if you are using your own ssh 
+                            key pair, paste the private key in the private key box to the left and the public key in 
+                            the box below.',
     'select_repository_type' => 'Select repository type...',
     'github' => 'GitHub',
     'bitbucket' => 'Bitbucket',

--- a/PHPCI/View/ProjectForm.phtml
+++ b/PHPCI/View/ProjectForm.phtml
@@ -19,7 +19,7 @@
             <div class="box-body">
                     <p><?php Lang::out('public_key_help'); ?></p>
 
-                    <textarea style="width: 90%; height: 150px;"><?php print $key ?></textarea>
+                    <textarea id="pubkey-input" style="width: 90%; height: 150px;"><?php print $key ?></textarea>
             </div>
         </div>
     </div>

--- a/public/assets/js/phpci.js
+++ b/public/assets/js/phpci.js
@@ -379,6 +379,11 @@ var PHPCIConfirmDialog = Class.extend({
  */
 function setupProjectForm()
 {
+    $('#pubkey-input').bind('input propertychange', function () {
+        var el = $(this);
+        $('#pubkey-hidden').val(el.val());
+    });
+
     $('.github-container').hide();
 
     $('#element-reference').change(function()


### PR DESCRIPTION
When pasting a public key in during project creation/editing, the value wasn't stored due to the textarea not updating the hidden input in the form. 

This pull request adds a bit of jQuery to bind the textarea value to the hidden input value.